### PR TITLE
test(ui): Add test cases.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ jetbrains-kotlinx-coroutines = "1.10.2"
 jetbrains-kotlinx-serialization = "1.8.1"
 jetbrains-kotlinx-collections = "0.3.8"
 io-ktor = "3.1.0"
+io-mockk = "1.14.0"
 ktlint = "12.2.0"
 
 [libraries]
@@ -29,6 +30,7 @@ io-ktor-client-serialization = { group = "io.ktor", name = "ktor-client-serializ
 io-ktor-client-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "io-ktor" }
 io-ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "io-ktor" }
 io-ktor-kotlinx-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "io-ktor" }
+io-mockk = { group = "io.mockk", name = "mockk", version.ref = "io-mockk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -44,8 +44,15 @@ kotlin {
             implementation(libs.jetbrains.kotlinx.coroutines)
             implementation(libs.jetbrains.kotlinx.serialization.json)
         }
-        commonTest.dependencies {
-            implementation(libs.jetbrains.kotlin.test)
+        // Can't use commonTest because mockk can't be use in native
+        // FIXME https://github.com/mockk/mockk/issues/950
+        val desktopTest by getting {
+            dependencies {
+                implementation(compose.desktop.uiTestJUnit4)
+                implementation(compose.desktop.currentOs)
+                implementation(libs.jetbrains.kotlin.test)
+                implementation(libs.io.mockk)
+            }
         }
     }
 }

--- a/ui/src/commonMain/kotlin/com/paligot/jsonforms/ui/JsonForm.kt
+++ b/ui/src/commonMain/kotlin/com/paligot/jsonforms/ui/JsonForm.kt
@@ -29,7 +29,6 @@ import com.paligot.jsonforms.kotlin.models.uischema.UiSchema
  * JsonForm(
  *     schema = schema,
  *     uiSchema = uiSchema,
- *     renderer = VitaminRenderer,
  *     state = jsonFormsState
  * )
  * ```

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormStateTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormStateTest.kt
@@ -1,0 +1,116 @@
+package com.paligot.jsonforms.ui
+
+import androidx.compose.runtime.State
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.paligot.jsonforms.kotlin.internal.FieldError
+import com.paligot.jsonforms.kotlin.models.schema.ObjectProperty
+import com.paligot.jsonforms.kotlin.models.schema.StringProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import com.paligot.jsonforms.kotlin.models.uischema.VerticalLayout
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Rule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class JsonFormStateTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `set() updates the value of a field`() {
+        val jsonFormState = JsonFormStateImpl(mapOf("field1" to "value1"))
+        jsonFormState["field1"] = "newValue"
+
+        assertEquals("newValue", jsonFormState.getValue("field1"))
+    }
+
+    @Test
+    fun `getData() returns the current form data`() {
+        val initialData = mapOf("field1" to "value1", "field2" to 42)
+        val jsonFormState = JsonFormStateImpl(initialData)
+
+        assertEquals(initialData, jsonFormState.getData())
+    }
+
+    @Test
+    fun `validate() returns true when there are no errors`() =
+        runBlocking {
+            val jsonFormState = JsonFormStateImpl(mapOf("field1" to "value1"))
+            val schema =
+                ObjectProperty(
+                    properties = persistentMapOf("field1" to StringProperty()),
+                )
+            val uiSchema =
+                VerticalLayout(
+                    elements = persistentListOf(Control(scope = "#/properties/field1")),
+                )
+
+            val result = jsonFormState.validate(schema, uiSchema)
+
+            assertTrue(result)
+        }
+
+    @Test
+    fun `validate() returns false when there are errors`() =
+        runBlocking {
+            val jsonFormState = JsonFormStateImpl(mapOf("field1" to "invalid"))
+            val schema =
+                ObjectProperty(
+                    properties = persistentMapOf("field1" to StringProperty(pattern = "abc")),
+                )
+            val uiSchema =
+                VerticalLayout(
+                    elements = persistentListOf(Control(scope = "#/properties/field1")),
+                )
+
+            val result = jsonFormState.validate(schema, uiSchema)
+
+            assertFalse(result)
+        }
+
+    @Test
+    fun `markAsErrors() adds custom errors`() {
+        val jsonFormState = JsonFormStateImpl(mapOf("field1" to "value1"))
+        val errors =
+            listOf(
+                FieldError.InvalidValueFieldError(value = JsonPrimitive(""), scope = "field1"),
+            )
+
+        jsonFormState.markAsErrors(errors)
+
+        composeTestRule.setContent {
+            val errorState: State<FieldError?> = jsonFormState.error("field1")
+            assertEquals("field1", errorState.value?.scope)
+        }
+    }
+
+    @Test
+    fun `get() observes changes to a field`() {
+        val jsonFormState = JsonFormStateImpl(mapOf("field1" to "value1"))
+        jsonFormState["field1"] = "newValue"
+        composeTestRule.setContent {
+            val state: State<Any?> = jsonFormState["field1"]
+            assertEquals("newValue", state.value)
+        }
+    }
+
+    @Test
+    fun `error() observes changes to error state`() {
+        val jsonFormState = JsonFormStateImpl(mapOf("field1" to "value1"))
+        val errors =
+            listOf(
+                FieldError.InvalidValueFieldError(value = JsonPrimitive(""), scope = "field1"),
+            )
+
+        jsonFormState.markAsErrors(errors)
+        composeTestRule.setContent {
+            val errorState: State<FieldError?> = jsonFormState.error("field1")
+            assertEquals("Field field1 has invalid value \"\"", errorState.value?.message)
+        }
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormTest.kt
@@ -1,0 +1,108 @@
+package com.paligot.jsonforms.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.paligot.jsonforms.kotlin.models.schema.BooleanProperty
+import com.paligot.jsonforms.kotlin.models.schema.NumberProperty
+import com.paligot.jsonforms.kotlin.models.schema.Schema
+import com.paligot.jsonforms.kotlin.models.schema.StringProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import com.paligot.jsonforms.kotlin.models.uischema.VerticalLayout
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import org.junit.Rule
+import org.junit.Test
+
+class JsonFormTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `renders string content`() {
+        val schema =
+            Schema(
+                properties = persistentMapOf("stringField" to StringProperty()),
+            )
+        val uiSchema = Control(scope = "#/properties/stringField")
+        composeTestRule.setContent {
+            val state = rememberJsonFormState(initialValues = mutableMapOf())
+            JsonForm(
+                schema = schema,
+                uiSchema = uiSchema,
+                state = state,
+                layoutContent = { error("Should not render Layout") },
+                stringContent = { id -> assert(id == "stringField") },
+                numberContent = { error("Should not render NumberProperty") },
+                booleanContent = { error("Should not render BooleanProperty") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders number content`() {
+        val schema =
+            Schema(
+                properties = persistentMapOf("numberField" to NumberProperty()),
+            )
+        val uiSchema = Control(scope = "#/properties/numberField")
+
+        composeTestRule.setContent {
+            val state = rememberJsonFormState(initialValues = mutableMapOf())
+            JsonForm(
+                schema = schema,
+                uiSchema = uiSchema,
+                state = state,
+                layoutContent = { error("Should not render Layout") },
+                stringContent = { error("Should not render StringProperty") },
+                numberContent = { id -> assert(id == "numberField") },
+                booleanContent = { error("Should not render BooleanProperty") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders boolean content`() {
+        val schema =
+            Schema(
+                properties = persistentMapOf("booleanField" to BooleanProperty()),
+            )
+        val uiSchema = Control(scope = "#/properties/booleanField")
+
+        composeTestRule.setContent {
+            val state = rememberJsonFormState(initialValues = mutableMapOf())
+            JsonForm(
+                schema = schema,
+                uiSchema = uiSchema,
+                state = state,
+                layoutContent = { error("Should not render Layout") },
+                stringContent = { error("Should not render StringProperty") },
+                numberContent = { error("Should not render NumberProperty") },
+                booleanContent = { id -> assert(id == "booleanField") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders layout content`() {
+        val schema =
+            Schema(
+                properties = persistentMapOf("stringField" to StringProperty()),
+            )
+        val uiSchema =
+            VerticalLayout(
+                elements = persistentListOf(Control(scope = "#/properties/stringField")),
+            )
+
+        composeTestRule.setContent {
+            val state = rememberJsonFormState(initialValues = mutableMapOf())
+            JsonForm(
+                schema = schema,
+                uiSchema = uiSchema,
+                state = state,
+                layoutContent = { assert(this.isVerticalLayout()) },
+                stringContent = { id -> assert(id == "stringField") },
+                numberContent = { error("Should not render NumberProperty") },
+                booleanContent = { error("Should not render BooleanProperty") },
+            )
+        }
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/LayoutTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/LayoutTest.kt
@@ -1,0 +1,117 @@
+package com.paligot.jsonforms.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.paligot.jsonforms.kotlin.models.schema.StringProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Condition
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import com.paligot.jsonforms.kotlin.models.uischema.Effect
+import com.paligot.jsonforms.kotlin.models.uischema.GroupLayout
+import com.paligot.jsonforms.kotlin.models.uischema.HorizontalLayout
+import com.paligot.jsonforms.kotlin.models.uischema.VerticalLayout
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Rule
+import org.junit.Test
+
+class LayoutTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `renders VerticalLayout with children`() {
+        val uiSchema = VerticalLayout()
+        val jsonFormState = mockk<JsonFormState>()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        composeTestRule.setContent {
+            Layout(
+                uiSchema = uiSchema,
+                jsonFormState = jsonFormState,
+                layoutContent = { assert(this.isVerticalLayout()) },
+                content = { error("Should not render Control") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders HorizontalLayout with children`() {
+        val uiSchema = HorizontalLayout()
+        val jsonFormState = mockk<JsonFormState>()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        composeTestRule.setContent {
+            Layout(
+                uiSchema = uiSchema,
+                jsonFormState = jsonFormState,
+                layoutContent = { assert(this.isHorizontalLayout()) },
+                content = { error("Should not render Control") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders GroupLayout with children`() {
+        val uiSchema = GroupLayout(label = "Group Label")
+        val jsonFormState = mockk<JsonFormState>()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        composeTestRule.setContent {
+            Layout(
+                uiSchema = uiSchema,
+                jsonFormState = jsonFormState,
+                layoutContent = { assert(this.isGroupLayout()) },
+                content = { error("Should not render Control") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders Control`() {
+        val uiSchema = Control(scope = "#/properties/string")
+        val jsonFormState = mockk<JsonFormState>()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        composeTestRule.setContent {
+            Layout(
+                uiSchema = uiSchema,
+                jsonFormState = jsonFormState,
+                layoutContent = { error("Should not render layout") },
+                content = { control -> assert(control.scope == "#/properties/string") },
+            )
+        }
+    }
+
+    @Test
+    fun `hides layout when rule evaluates to false`() {
+        val uiSchema =
+            GroupLayout(
+                label = "Hidden Group",
+                rule =
+                    com.paligot.jsonforms.kotlin.models.uischema.Rule(
+                        effect = Effect.Show,
+                        condition =
+                            Condition(
+                                scope = "#/properties/not_exist",
+                                schema = StringProperty(const = JsonPrimitive("not exist")),
+                            ),
+                    ),
+            )
+        val jsonFormState = mockk<JsonFormState>()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        composeTestRule.setContent {
+            Layout(
+                uiSchema = uiSchema,
+                jsonFormState = jsonFormState,
+                layoutContent = { error("Should not render layout") },
+                content = { error("Should not render Control") },
+            )
+        }
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/PropertyTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/PropertyTest.kt
@@ -1,0 +1,80 @@
+package com.paligot.jsonforms.ui
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.paligot.jsonforms.kotlin.SchemaProvider
+import com.paligot.jsonforms.kotlin.models.schema.BooleanProperty
+import com.paligot.jsonforms.kotlin.models.schema.NumberProperty
+import com.paligot.jsonforms.kotlin.models.schema.StringProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+
+class PropertyTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `renders StringProperty with correct scope`() {
+        val control = Control(scope = "#/properties/string")
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val property = StringProperty()
+
+        every { schemaProvider.getPropertyByControl<StringProperty>(control) } returns property
+
+        composeTestRule.setContent {
+            Property(
+                control = control,
+                schemaProvider = schemaProvider,
+                jsonFormState = jsonFormState,
+                stringContent = { id -> assert(id == "string") },
+                numberContent = { error("Should not render NumberProperty") },
+                booleanContent = { error("Should not render BooleanProperty") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders BooleanProperty with correct scope`() {
+        val control = Control(scope = "#/properties/boolean")
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val property = BooleanProperty()
+
+        every { schemaProvider.getPropertyByControl<BooleanProperty>(control) } returns property
+
+        composeTestRule.setContent {
+            Property(
+                control = control,
+                schemaProvider = schemaProvider,
+                jsonFormState = jsonFormState,
+                stringContent = { error("Should not render StringProperty") },
+                numberContent = { error("Should not render NumberProperty") },
+                booleanContent = { id -> assert(id == "boolean") },
+            )
+        }
+    }
+
+    @Test
+    fun `renders NumberProperty with correct scope`() {
+        val control = Control(scope = "#/properties/number")
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val property = NumberProperty()
+
+        every { schemaProvider.getPropertyByControl<NumberProperty>(control) } returns property
+
+        composeTestRule.setContent {
+            Property(
+                control = control,
+                schemaProvider = schemaProvider,
+                jsonFormState = jsonFormState,
+                stringContent = { error("Should not render StringProperty") },
+                numberContent = { id -> assert(id == "number") },
+                booleanContent = { error("Should not render BooleanProperty") },
+            )
+        }
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererBooleanScopeTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererBooleanScopeTest.kt
@@ -1,0 +1,86 @@
+package com.paligot.jsonforms.ui
+
+import com.paligot.jsonforms.kotlin.SchemaProvider
+import com.paligot.jsonforms.kotlin.models.schema.BooleanProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import com.paligot.jsonforms.kotlin.models.uischema.ControlOptions
+import com.paligot.jsonforms.kotlin.models.uischema.Format
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RendererBooleanScopeTest {
+    @Test
+    fun `test isToggle returns true when control is toggle`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control =
+            Control(
+                scope = "#/properties/check",
+                options = ControlOptions(format = Format.Toggle),
+            )
+        val booleanProperty = BooleanProperty()
+
+        every { schemaProvider.getPropertyByControl<BooleanProperty>(control) } returns booleanProperty
+
+        val scope =
+            RendererBooleanScopeInstance(control, schemaProvider, jsonFormState, booleanProperty)
+
+        assertTrue(scope.isToggle())
+    }
+
+    @Test
+    fun `test label returns correct label`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control =
+            Control(
+                scope = "#/properties/check",
+                label = "Test label",
+                options = ControlOptions(format = Format.Toggle),
+            )
+        val booleanProperty = BooleanProperty()
+
+        every { schemaProvider.getPropertyByControl<BooleanProperty>(control) } returns booleanProperty
+        every { schemaProvider.propertyIsRequired(control, any()) } returns true
+        every { jsonFormState.getData() } returns mapOf()
+
+        val scope =
+            RendererBooleanScopeInstance(control, schemaProvider, jsonFormState, booleanProperty)
+
+        assertEquals("Test label*", scope.label())
+    }
+
+    @Test
+    fun `test description returns correct description`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = mockk<Control>()
+        val booleanProperty = BooleanProperty(description = "Test Description")
+
+        every { schemaProvider.getPropertyByControl<BooleanProperty>(control) } returns booleanProperty
+
+        val scope =
+            RendererBooleanScopeInstance(control, schemaProvider, jsonFormState, booleanProperty)
+
+        assertEquals("Test Description", scope.description())
+    }
+
+    @Test
+    fun `test enabled returns true when property is enabled`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = Control(scope = "#/properties/check")
+        val booleanProperty = BooleanProperty()
+
+        every { schemaProvider.getPropertyByControl<BooleanProperty>(control) } returns booleanProperty
+        every { jsonFormState.getData() } returns mapOf()
+
+        val scope =
+            RendererBooleanScopeInstance(control, schemaProvider, jsonFormState, booleanProperty)
+
+        assertTrue(scope.enabled())
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererLayoutScopeTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererLayoutScopeTest.kt
@@ -1,0 +1,86 @@
+package com.paligot.jsonforms.ui
+
+import com.paligot.jsonforms.kotlin.models.uischema.GroupLayout
+import com.paligot.jsonforms.kotlin.models.uischema.HorizontalLayout
+import com.paligot.jsonforms.kotlin.models.uischema.LayoutOptions
+import com.paligot.jsonforms.kotlin.models.uischema.VerticalLayout
+import kotlinx.collections.immutable.persistentListOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RendererLayoutScopeTest {
+    @Test
+    fun `isVerticalLayout() returns true for VerticalLayout`() {
+        val uiSchema = VerticalLayout()
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertTrue(scope.isVerticalLayout())
+        assertFalse(scope.isHorizontalLayout())
+        assertFalse(scope.isGroupLayout())
+    }
+
+    @Test
+    fun `isHorizontalLayout() returns true for HorizontalLayout`() {
+        val uiSchema = HorizontalLayout()
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertTrue(scope.isHorizontalLayout())
+        assertFalse(scope.isVerticalLayout())
+        assertFalse(scope.isGroupLayout())
+    }
+
+    @Test
+    fun `isGroupLayout() returns true for GroupLayout`() {
+        val uiSchema = GroupLayout(label = "Group Label")
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertTrue(scope.isGroupLayout())
+        assertFalse(scope.isVerticalLayout())
+        assertFalse(scope.isHorizontalLayout())
+    }
+
+    @Test
+    fun `title() returns label for GroupLayout`() {
+        val uiSchema = GroupLayout(label = "Group Label")
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertEquals("Group Label", scope.title())
+    }
+
+    @Test
+    fun `description() returns description for GroupLayout`() {
+        val uiSchema = GroupLayout(label = "Group Label", description = "Group Description")
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertEquals("Group Description", scope.description())
+    }
+
+    @Test
+    fun `elements() returns elements of UiSchema`() {
+        val childElement = VerticalLayout()
+        val uiSchema = GroupLayout(label = "Group Label", elements = persistentListOf(childElement))
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertEquals(listOf(childElement), scope.elements())
+    }
+
+    @Test
+    fun `verticalSpacing() returns correct spacing`() {
+        val options = LayoutOptions(verticalSpacing = "10dp")
+        val uiSchema = VerticalLayout(options = options)
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertEquals("10dp", scope.verticalSpacing())
+    }
+
+    @Test
+    fun `horizontalSpacing() returns correct spacing`() {
+        val options = LayoutOptions(horizontalSpacing = "15dp")
+        val uiSchema = HorizontalLayout(options = options)
+        val scope: RendererLayoutScope = RendererLayoutScopeInstance(uiSchema)
+
+        assertEquals("15dp", scope.horizontalSpacing())
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererNumberScopeTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererNumberScopeTest.kt
@@ -1,0 +1,79 @@
+package com.paligot.jsonforms.ui
+
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import com.paligot.jsonforms.kotlin.SchemaProvider
+import com.paligot.jsonforms.kotlin.models.schema.NumberProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RendererNumberScopeTest {
+    @Test
+    fun `label() returns the correct label`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control =
+            Control(
+                scope = "#/properties/number",
+                label = "My label",
+            )
+        val property = NumberProperty()
+
+        every { schemaProvider.propertyIsRequired(control, any()) } returns true
+        every { jsonFormState.getData() } returns mapOf()
+
+        val scope = RendererNumberScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertEquals("My label*", scope.label())
+    }
+
+    @Test
+    fun `description() returns the description`() {
+        val control = mockk<Control>()
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val property = NumberProperty(description = "Test description")
+
+        val scope = RendererNumberScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertEquals("Test description", scope.description())
+    }
+
+    @Test
+    fun `enabled() returns true if the field is enabled`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = Control(scope = "#/properties/number")
+        val property = NumberProperty()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        val scope = RendererNumberScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertTrue(scope.enabled())
+    }
+
+    @Test
+    fun `keyboardOptions() returns the correct options`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = Control(scope = "#/properties/number")
+        val property = NumberProperty()
+
+        val options =
+            RendererNumberScopeInstance(control, schemaProvider, jsonFormState, property)
+                .keyboardOptions(
+                    capitalization = KeyboardCapitalization.None,
+                    imeAction = ImeAction.Done,
+                )
+
+        assertEquals(KeyboardCapitalization.None, options.capitalization)
+        assertEquals(KeyboardType.Number, options.keyboardType)
+        assertEquals(ImeAction.Done, options.imeAction)
+    }
+}

--- a/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererStringScopeTest.kt
+++ b/ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererStringScopeTest.kt
@@ -1,0 +1,112 @@
+package com.paligot.jsonforms.ui
+
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import com.paligot.jsonforms.kotlin.SchemaProvider
+import com.paligot.jsonforms.kotlin.models.schema.StringProperty
+import com.paligot.jsonforms.kotlin.models.uischema.Control
+import com.paligot.jsonforms.kotlin.models.uischema.ControlOptions
+import com.paligot.jsonforms.kotlin.models.uischema.Format
+import com.paligot.jsonforms.kotlin.models.uischema.Orientation
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RendererStringScopeTest {
+    @Test
+    fun `label() returns the correct label`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = Control(scope = "#/properties/string", label = "My label")
+        val property = StringProperty()
+
+        every { schemaProvider.propertyIsRequired(control, any()) } returns true
+        every { jsonFormState.getData() } returns mapOf()
+
+        val scope = RendererStringScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertEquals("My label*", scope.label())
+    }
+
+    @Test
+    fun `description() returns the description`() {
+        val control = mockk<Control>()
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val property = StringProperty(description = "Test description")
+
+        val scope = RendererStringScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertEquals("Test description", scope.description())
+    }
+
+    @Test
+    fun `enabled() returns true if the field is enabled`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = Control(scope = "#/properties/string")
+        val property = StringProperty()
+
+        every { jsonFormState.getData() } returns mapOf()
+
+        val scope = RendererStringScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertTrue(scope.enabled())
+    }
+
+    @Test
+    fun `visualTransformation() returns PasswordVisualTransformation for password fields`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control =
+            Control(
+                scope = "#/properties/password",
+                options = ControlOptions(format = Format.Password),
+            )
+        val property = StringProperty()
+
+        val scope = RendererStringScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertEquals(PasswordVisualTransformation(), scope.visualTransformation())
+    }
+
+    @Test
+    fun `keyboardOptions() returns the correct options`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control = Control(scope = "#/properties/string")
+        val property = StringProperty()
+
+        val options =
+            RendererStringScopeInstance(control, schemaProvider, jsonFormState, property)
+                .keyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences,
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Done,
+                )
+
+        assertEquals(KeyboardCapitalization.Sentences, options.capitalization)
+        assertEquals(KeyboardType.Text, options.keyboardType)
+        assertEquals(ImeAction.Done, options.imeAction)
+    }
+
+    @Test
+    fun `orientation() returns the correct orientation`() {
+        val schemaProvider = mockk<SchemaProvider>()
+        val jsonFormState = mockk<JsonFormState>()
+        val control =
+            Control(
+                scope = "#/properties/string",
+                options = ControlOptions(orientation = Orientation.HORIZONTALLY),
+            )
+        val property = StringProperty()
+
+        val scope = RendererStringScopeInstance(control, schemaProvider, jsonFormState, property)
+
+        assertEquals(Orientation.HORIZONTALLY, scope.orientation())
+    }
+}


### PR DESCRIPTION
This pull request introduces several updates, including dependency additions, test suite enhancements, and a minor code cleanup. The most significant changes involve adding new dependencies (`io-mockk`) and implementing extensive desktop test cases for various components of the `ui` module.

### Dependency Updates:
* Added `io-mockk` version `1.14.0` to the project dependencies for mocking capabilities in tests. (`gradle/libs.versions.toml`)

### Test Suite Enhancements:
* **JsonForm State Tests**: Added comprehensive tests for `JsonFormStateImpl` to validate field updates, data retrieval, validation logic, error handling, and state observation. (`ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormStateTest.kt`, [ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormStateTest.ktR1-R116](diffhunk://#diff-c89a0f7235087c6c459037a897996916450038071de741e70cda0a0d8cece6acR1-R116))
* **JsonForm Rendering Tests**: Introduced tests for rendering different schema properties (`StringProperty`, `NumberProperty`, etc.) and layouts (`VerticalLayout`, `HorizontalLayout`, etc.) in `JsonForm`. (`ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormTest.kt`, [ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/JsonFormTest.ktR1-R108](diffhunk://#diff-b1883ae2fb94e6891ff22ae77a38553935384a4e6d2791de6797608419be4886R1-R108))
* **Layout Rendering Tests**: Added tests to verify the behavior of `Layout` components, including `VerticalLayout`, `HorizontalLayout`, `GroupLayout`, and rule-based visibility. (`ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/LayoutTest.kt`, [ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/LayoutTest.ktR1-R117](diffhunk://#diff-4213609b655d3a8aa614ace1b8dd4883ce468605829d9d2401e2f0765c22aa5fR1-R117))
* **Property Rendering Tests**: Added tests to ensure correct rendering of `StringProperty`, `NumberProperty`, and `BooleanProperty` within the `Property` component. (`ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/PropertyTest.kt`, [ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/PropertyTest.ktR1-R80](diffhunk://#diff-1a867d671608b9d30afd55848940ddc630d3c296357abf11c927cad0f4cda954R1-R80))
* **Renderer Scope Tests**: Added tests for `RendererBooleanScope` and `RendererLayoutScope` to validate functionality like toggle detection, label retrieval, layout type identification, and spacing options. (`ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererBooleanScopeTest.kt`, [[1]](diffhunk://#diff-ec7d8f36fd77b50ca70af0607ccac0cc032d0b0e7004ce6f481dda8f055700e7R1-R86); `ui/src/desktopTest/kotlin/com/paligot/jsonforms/ui/RendererLayoutScopeTest.kt`, [[2]](diffhunk://#diff-8d9cf842af7c1fb0907d9a98a3337baea959f2dc23217691020ee4694b43ae4cR1-R86)

### Minor Code Cleanup:
* Removed the unused `renderer` parameter from the `JsonForm` documentation example. (`ui/src/commonMain/kotlin/com/paligot/jsonforms/ui/JsonForm.kt`, [ui/src/commonMain/kotlin/com/paligot/jsonforms/ui/JsonForm.ktL32](diffhunk://#diff-546633e70f91fe576e5c09ee4ff96fad7f28a3c4cbceac307ba9981c249e4dc3L32))