### PR TITLE
Be able to publish artifacts to Maven Central

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 concurrency:
   group: build-${{ github.ref }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,36 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          build-scan-publish: true
+          build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-use-agree: "yes"
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Publishing to Maven Central
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository
+        env:
+          ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
+          ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
+          ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
+          ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}

--- a/README.md
+++ b/README.md
@@ -162,17 +162,16 @@ This diagram illustrates the modular architecture of `jsonforms-kotlin`:
 
 ## Download
 
-The `jsonforms-kotlin` library is not yet available on Maven Central. However, it will be published there in the future.
-
-Once available, you will be able to include it in your `build.gradle.kts` file like this:
+The `jsonforms-kotlin` library is not yet available on Maven Central in release mode but you can 
+already use the latest SNAPSHOT version, `1.0.0-SNAPSHOT`.
 
 ```kotlin
-// In your shared, Android, iOS, or JVM module's build.gradle.kts
+val version = "1.0.0-SNAPSHOT"
 dependencies {
-    implementation("com.paligot.jsonforms.kotlin:core:VERSION")
-    implementation("com.paligot.jsonforms.kotlin:ui:VERSION")
-    implementation("com.paligot.jsonforms.kotlin:material3:VERSION")
-    implementation("com.paligot.jsonforms.kotlin:cupertino:VERSION")
+    implementation("com.paligot.jsonforms.kotlin:core:$version")
+    implementation("com.paligot.jsonforms.kotlin:ui:$version")
+    implementation("com.paligot.jsonforms.kotlin:material3:$version")
+    implementation("com.paligot.jsonforms.kotlin:cupertino:$version")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.multiplatform).apply(false)
     alias(libs.plugins.jetbrains.kotlin.serialization).apply(false)
     alias(libs.plugins.ktlint).apply(false)
+    alias(libs.plugins.vanniktech.maven.publish).apply(false)
 }
 
 subprojects {

--- a/cupertino/build.gradle.kts
+++ b/cupertino/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.jetbrains.compose.compiler)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.vanniktech.maven.publish)
 }
 
 kotlin {
@@ -77,5 +78,12 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+mavenPublishing {
+    pom {
+        name.set("cupertino")
+        description.set("Implement a Renderer for the Apple ecosystem, leveraging the compose-cupertino library.")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,25 @@ kotlin.code.style=official
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+#Publishing
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+
+GROUP=com.paligot.jsonforms.kotlin
+VERSION_NAME=1.0.0-SNAPSHOT
+
+POM_INCEPTION_YEAR=2025
+POM_URL=https://github.com/GerardPaligot/jsonforms-kotlin
+
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENSE_DIST=repo
+
+POM_SCM_URL=https://github.com/GerardPaligot/jsonforms-kotlin/
+POM_SCM_CONNECTION=scm:git:git://github.com/GerardPaligot/jsonforms-kotlin.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/GerardPaligot/jsonforms-kotlin.git
+
+POM_DEVELOPER_ID=gerardpaligot
+POM_DEVELOPER_NAME=Gérard Paligot
+POM_DEVELOPER_URL=https://github.com/GerardPaligot/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ jetbrains-kotlinx-collections = "0.3.8"
 io-ktor = "3.1.0"
 io-mockk = "1.14.0"
 ktlint = "12.2.0"
+maven-publish = "0.31.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -40,6 +41,7 @@ jetbrains-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", versi
 jetbrains-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "jetbrains-kotlin" }
 jetbrains-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "jetbrains-kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 
 [bundles]
 io-ktor-client = [

--- a/material3/build.gradle.kts
+++ b/material3/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.jetbrains.compose.compiler)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.vanniktech.maven.publish)
 }
 
 kotlin {
@@ -76,5 +77,12 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+mavenPublishing {
+    pom {
+        name.set("material3")
+        description.set("Implement a Renderer specifically for the Material 3 design system.")
     }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.kotlin.serialization)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.vanniktech.maven.publish)
 }
 
 kotlin {
@@ -71,5 +72,12 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+mavenPublishing {
+    pom {
+        name.set("core")
+        description.set("Core data models for JSON Schema, UI Schema, and the data handled by the forms")
     }
 }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.jetbrains.compose.compiler)
     alias(libs.plugins.ktlint)
+    alias(libs.plugins.vanniktech.maven.publish)
 }
 
 kotlin {
@@ -84,5 +85,12 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+mavenPublishing {
+    pom {
+        name.set("ui")
+        description.set("JsonForm composable and defines the Renderer interface.")
     }
 }


### PR DESCRIPTION
This pull request introduces significant updates to the build configuration and publishing setup for the `jsonforms-kotlin` project. Key changes include the addition of workflows for publishing to Maven Central, updates to the Gradle build scripts to enable Maven publishing, and improvements to the documentation to reflect the availability of the SNAPSHOT version.

### Workflow Changes:
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L4-L6): Removed the `push` trigger for the `main` branch, leaving only the `pull_request` trigger to streamline build processes.
* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR1-R36): Added a new workflow for publishing artifacts to Maven Central, including steps for setting up Java, Gradle, and executing the `publishAllPublicationsToMavenCentralRepository` Gradle task.

### Gradle Build Script Enhancements:
* `cupertino/build.gradle.kts`, `material3/build.gradle.kts`, `shared/build.gradle.kts`, `ui/build.gradle.kts`: Added `vanniktech.maven.publish` plugin and configured `mavenPublishing` blocks to define POM metadata for Maven Central publishing. [[1]](diffhunk://#diff-993991aad7b9536d5362279946a7b634675af5b9136fa84d59e40819ad0b6b35R10) [[2]](diffhunk://#diff-993991aad7b9536d5362279946a7b634675af5b9136fa84d59e40819ad0b6b35R83-R89) [[3]](diffhunk://#diff-ac33294d83ed5290bbc80e1a41dcc89b498c676eced8854d527c457a1ac31374R10) [[4]](diffhunk://#diff-ac33294d83ed5290bbc80e1a41dcc89b498c676eced8854d527c457a1ac31374R82-R88) [[5]](diffhunk://#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bR9) [[6]](diffhunk://#diff-cf9ae3b1eb7273a914f22b1e6d22d8447f88df0e7245a5b856fb751e507b979bR77-R83) [[7]](diffhunk://#diff-3803117f2e191ba821fa5195538f47c1528620ec267c7f961ccbf8712348467fR11) [[8]](diffhunk://#diff-3803117f2e191ba821fa5195538f47c1528620ec267c7f961ccbf8712348467fR90-R96)

### Dependency Management:
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR15): Added the `vanniktech.maven.publish` plugin to the dependency catalog for consistent usage across modules. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR15) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR44)

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L165-R174): Updated the download instructions to reflect the availability of the `1.0.0-SNAPSHOT` version on Maven Central, replacing placeholder text with the actual version variable.

### Gradle Properties Configuration:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R13-R34): Added properties required for Maven Central publishing, such as signing configurations, project metadata, and developer information.