### PR TITLE
docs: Customization & theming

### DIFF
--- a/docs/create-renderer.md
+++ b/docs/create-renderer.md
@@ -1,0 +1,117 @@
+This page explains how to create your own renderer for `jsonforms-kotlin`, allowing you to fully 
+customize the look and feel of forms to match your internal design system or branding. This is 
+useful if the provided renderers do not meet your requirements.
+
+## What is a renderer?
+
+A renderer is a set of composable functions that define how each form field and layout should be 
+displayed. You implement these by providing composable extensions for the various scope interfaces: 
+`RendererStringScope`, `RendererNumberScope`, `RendererBooleanScope`, and `RendererLayoutScope`.
+
+## Steps to create a custom renderer
+
+**Implement field renderers**: Create composable extension functions for each field type and use the scope API to access field metadata, options, and state.
+
+* `RendererStringScope.YourStringProperty(...)`
+* `RendererNumberScope.YourNumberProperty(...)`
+* `RendererBooleanScope.YourBooleanProperty(...)`
+
+**Implement layout renderer**: Create a composable extension for `RendererLayoutScope` 
+(e.g., `YourLayout(...)`) to control how groups of fields are arranged (vertical, horizontal, etc).
+
+**Use your Renderer in JsonForm**: Pass your custom composables to the `JsonForm` component's 
+`layoutContent`, `stringContent`, `numberContent`, and `booleanContent` slots.
+
+**Example: Minimal custom renderer**
+
+```kotlin
+@Composable
+fun RendererStringScope.MyStringProperty(
+    value: String?,
+    error: String? = null,
+    onValueChange: (String) -> Unit,
+) {
+    // Use scope methods for label, enabled, etc.
+    MyTextField(
+        value = value ?: "",
+        label = label(),
+        enabled = enabled(),
+        error = error,
+        onValueChange = onValueChange
+    )
+}
+
+@Composable
+fun RendererNumberScope.MyNumberProperty(
+    value: String?,
+    error: String? = null,
+    onValueChange: (String) -> Unit,
+) {
+    MyNumberField(
+        value = value ?: "",
+        label = label(),
+        enabled = enabled(),
+        error = error,
+        onValueChange = onValueChange
+    )
+}
+
+@Composable
+fun RendererBooleanScope.MyBooleanProperty(
+    value: Boolean,
+    onValueChange: (Boolean) -> Unit,
+) {
+    MySwitch(
+        checked = value,
+        label = label(),
+        enabled = enabled(),
+        onCheckedChange = onValueChange
+    )
+}
+
+@Composable
+fun RendererLayoutScope.MyLayout(
+    content: @Composable (UiSchema) -> Unit
+) {
+    Column {
+        elements().forEach { child ->
+            content(child)
+        }
+    }
+}
+```
+
+## Using your renderer
+
+```kotlin
+JsonForm(
+    schema = schema,
+    uiSchema = uiSchema,
+    state = state,
+    layoutContent = { MyLayout(content = it) },
+    stringContent = { scope ->
+        MyStringProperty(
+            value = state[scope.id].value as String?,
+            error = state.error(scope.id).value,
+            onValueChange = { state[scope.id] = it }
+        )
+    },
+    numberContent = { scope ->
+        MyNumberProperty(
+            value = state[scope.id].value as String?,
+            error = state.error(scope.id).value,
+            onValueChange = { state[scope.id] = it }
+        )
+    },
+    booleanContent = { scope ->
+        MyBooleanProperty(
+            value = state[scope.id].value as Boolean? ?: false,
+            onValueChange = { state[scope.id] = it }
+        )
+    }
+)
+```
+
+For more details, see the [API reference](api/index.html) and the source code of the 
+[Material3](../renderers/material3/) and [Cupertino](../renderers/cupertino/) renderers for 
+inspiration.

--- a/docs/create-renderer.md
+++ b/docs/create-renderer.md
@@ -113,5 +113,4 @@ JsonForm(
 ```
 
 For more details, see the [API reference](api/index.html) and the source code of the 
-[Material3](../renderers/material3/) and [Cupertino](../renderers/cupertino/) renderers for 
-inspiration.
+material3 and cupertino modules.

--- a/docs/custom-rendering.md
+++ b/docs/custom-rendering.md
@@ -1,0 +1,88 @@
+This page explains how to customize the default rendering of a `JsonForm` component in 
+`jsonforms-kotlin`. You can provide your own UI for specific fields or layouts by supplying custom 
+composable functions to the `JsonForm` component. This allows you to tailor the form's appearance 
+and behavior to your application's needs.
+
+## Why Customize Rendering?
+
+While the default renderers (such as Material3 or Cupertino) provide a consistent look and feel, 
+you may want to:
+ 
+* Integrate custom UI components (e.g., dropdowns, country pickers)
+* Change the layout or style of certain fields
+* Add special logic for user interaction
+
+## How to Customize Rendering
+
+You can customize rendering by providing your own implementations for the `layoutContent`, 
+`stringContent`, `numberContent`, and `booleanContent` slots in the `JsonForm` composable. Each 
+slot receives the necessary context (such as the field id and current value) and should emit your 
+custom ui component.
+
+**Example: Custom dropdown for country selection**
+
+Here, the `flags` field uses a custom dropdown, while other fields use the default Material3 
+renderer:
+
+```kotlin
+JsonForm(
+    schema = schema,
+    uiSchema = uiSchema,
+    state = state,
+    layoutContent = { Material3Layout(content = it) },
+    stringContent = { id ->
+        val value = state[id].value as String?
+        val error = state.error(id = id).value
+        if (id == "flags") {
+            FlagDropdownField(
+                value = value,
+                values = values(), // your list of country codes described in the schema
+                expanded = expanded,
+                onFlagClick = { expanded = !expanded },
+                onItemClick = { state[id] = it },
+                onDismissRequest = { expanded = false },
+            )
+        } else {
+            Material3StringProperty(
+                value = value,
+                error = error?.message,
+                onValueChange = { state[id] = it },
+            )
+        }
+    },
+    numberContent = {},
+    booleanContent = {},
+)
+```
+
+* The `stringContent` lambda checks the field id. If it's `flags`, it renders a custom dropdown. Otherwise, it falls back to the default Material3 field.
+* You can use this pattern to override rendering for any field or layout.
+
+## Accessing data from schema and UI schema
+
+When customizing rendering, the `stringContent`, `numberContent`, and `booleanContent` slots each
+receive a specialized scope object: `RendererStringScope`, `RendererNumberScope`, or
+`RendererBooleanScope`.
+
+These scope interfaces provide a rich API to access metadata and configuration for the field being
+rendered, by connecting the UI schema (which describes the form layout and controls) with the JSON
+schema (which describes the data model and validation rules). The internal implementation of each
+scope uses both schemas and the current form state to provide the following:
+
+```kotlin
+stringContent = { id ->
+    val value = state[id].value as String?
+    val error = state.error(id).value
+    val label = this.label()
+    val enabled = this.enabled()
+    // ...render your custom field using this metadata...
+}
+```
+
+## Tips for Customization
+
+* You can mix and match custom and default renderers as needed.
+* Use the `state` object to read and update field values and errors.
+* You can provide custom logic for any field type (string, number, boolean, etc.) by implementing the corresponding content slot.
+
+For more details, see the [usage guide](usage.md) or the [API reference](api/index.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - "Overview": index.md
   - "Usage": usage.md
   - "State Management": state-management.md
+  - "Custom Rendering": custom-rendering.md
   - "API reference": api/index.html
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
   - "Usage": usage.md
   - "State Management": state-management.md
   - "Custom Rendering": custom-rendering.md
+  - "Create Renderer": create-renderer.md
   - "API reference": api/index.html
 
 theme:

--- a/renderers/cupertino/README.md
+++ b/renderers/cupertino/README.md
@@ -1,0 +1,54 @@
+# Cupertino Renderer
+
+This module provides a Cupertino-style renderer. It enables you to render dynamic forms using 
+Cupertino (Apple-like) components, fully compatible with Kotlin Multiplatform and Compose 
+Multiplatform projects.
+
+## Usage
+
+Add the dependency to your project:
+
+```kotlin
+dependencies {
+    implementation("com.paligot.jsonforms.kotlin:cupertino:<version>")
+}
+```
+
+In your Compose code, use the Cupertino renderer functions in the `JsonForm` component:
+
+```kotlin
+import com.paligot.jsonforms.cupertino.*
+
+JsonForm(
+    schema = schema,
+    uiSchema = uiSchema,
+    state = formState,
+    layoutContent = { CupertinoLayout(content = it) },
+    stringContent = { scope ->
+        CupertinoStringProperty(
+            value = formState[scope.id].value as String?,
+            error = formState.error(scope.id).value,
+            onValueChange = { formState[scope.id] = it }
+        )
+    },
+    numberContent = { scope ->
+        CupertinoNumberProperty(
+            value = formState[scope.id].value as String?,
+            error = formState.error(scope.id).value,
+            onValueChange = { formState[scope.id] = it }
+        )
+    },
+    booleanContent = { scope ->
+        CupertinoBooleanProperty(
+            value = formState[scope.id].value as Boolean? ?: false,
+            onValueChange = { formState[scope.id] = it }
+        )
+    }
+)
+```
+
+## Reference
+
+- [Usage guide](../../docs/usage.md)
+- [Custom rendering guide](../../docs/custom-rendering.md)
+- [Create a renderer guide](../../docs/create-renderer.md)

--- a/renderers/material3/README.md
+++ b/renderers/material3/README.md
@@ -1,0 +1,54 @@
+# Material3 Renderer
+
+This module provides a Material Design 3 (Material You) renderer. It enables you to render dynamic 
+forms using Material3 components, fully compatible with Kotlin Multiplatform and Compose 
+Multiplatform projects.
+
+## Usage
+
+Add the dependency to your project:
+
+```kotlin
+dependencies {
+    implementation("com.paligot.jsonforms.kotlin:material3:<version>")
+}
+```
+
+In your Compose code, use the Material3 renderer functions in the `JsonForm` component:
+
+```kotlin
+import com.paligot.jsonforms.material3.*
+
+JsonForm(
+    schema = schema,
+    uiSchema = uiSchema,
+    state = formState,
+    layoutContent = { Material3Layout(content = it) },
+    stringContent = { scope ->
+        Material3StringProperty(
+            value = formState[scope.id].value as String?,
+            error = formState.error(scope.id).value,
+            onValueChange = { formState[scope.id] = it }
+        )
+    },
+    numberContent = { scope ->
+        Material3NumberProperty(
+            value = formState[scope.id].value as String?,
+            error = formState.error(scope.id).value,
+            onValueChange = { formState[scope.id] = it }
+        )
+    },
+    booleanContent = { scope ->
+        Material3BooleanProperty(
+            value = formState[scope.id].value as Boolean? ?: false,
+            onValueChange = { formState[scope.id] = it }
+        )
+    }
+)
+```
+
+## Reference
+
+- [Usage guide](../../docs/usage.md)
+- [Custom rendering guide](../../docs/custom-rendering.md)
+- [Create a renderer guide](../../docs/create-renderer.md)


### PR DESCRIPTION
This pull request enhances the documentation for `jsonforms-kotlin` by adding detailed guides on creating custom renderers and customizing default rendering, as well as updating the navigation structure to include these new sections.

### Documentation Enhancements

* **Guide on creating custom renderers**: Added a new file `docs/create-renderer.md` that explains how to create custom renderers for `jsonforms-kotlin`. This includes implementing field and layout renderers, using the `Renderer*Scope` APIs, and integrating them into the `JsonForm` component. It also provides a minimal example of a custom renderer.
* **Guide on customizing default rendering**: Added a new file `docs/custom-rendering.md` that describes how to override default rendering in `JsonForm`. It explains the use of custom composable functions for specific fields or layouts and includes an example of a custom dropdown for country selection.

### Navigation Update

* **Updated `mkdocs.yml`**: Added links to the new "Custom Rendering" and "Create Renderer" documentation sections in the navigation menu.